### PR TITLE
🚀 Pull Request - Fix: Ensure Resource Capacity is a Positive Number

### DIFF
--- a/backend/reserve/serializers.py
+++ b/backend/reserve/serializers.py
@@ -2,6 +2,14 @@ from rest_framework import serializers
 from django.db.models import Q
 from .models import CustomUser, Auditorium, MeetingRoom, Vehicle, Reservation
 
+def validate_positive_capacity(value):
+    """
+    Garante que o valor da capacidade seja um número inteiro positivo maior que zero.
+    """
+    if value <= 0:
+        raise serializers.ValidationError("Capacity must be a positive number greater than zero.")
+    return value
+
 class CustomUserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, required=True)
     is_self = serializers.SerializerMethodField() 
@@ -35,6 +43,9 @@ class LoginSerializer(serializers.Serializer):
     identifier = serializers.CharField(required=True)
     password = serializers.CharField(required=True, write_only=True)
 class AuditoriumSerializer(serializers.ModelSerializer):
+
+    capacity = serializers.IntegerField(validators=[validate_positive_capacity])
+    
     class Meta:
         model = Auditorium
         fields = ['id', 'name', 'capacity', 'location']
@@ -45,6 +56,9 @@ class AuditoriumSerializer(serializers.ModelSerializer):
         return value
 
 class MeetingRoomSerializer(serializers.ModelSerializer):
+
+    capacity = serializers.IntegerField(validators=[validate_positive_capacity])
+    
     class Meta:
         model = MeetingRoom
         fields = ['id', 'name', 'capacity', 'location']
@@ -55,6 +69,8 @@ class MeetingRoomSerializer(serializers.ModelSerializer):
         return value
 
 class VehicleSerializer(serializers.ModelSerializer):
+    
+    capacity = serializers.IntegerField(validators=[validate_positive_capacity])
     class Meta:
         model = Vehicle
         fields = ['id', 'plate_number', 'model', 'capacity']


### PR DESCRIPTION
📌 Description
This PR fixes a data integrity bug where the capacity for resources (Auditoriums, Meeting Rooms, and Vehicles) could be set to negative or zero values. Validation has been added to the backend serializers to enforce that the capacity field must always be a positive integer greater than zero.

✅ Changes Made

    A reusable validator function, validate_positive_capacity, was created in serializers.py to ensure a value is greater than zero.

    This validator has been applied to the capacity field in the AuditoriumSerializer, MeetingRoomSerializer, and VehicleSerializer.

    Any API request attempting to create or update a resource with a non-positive capacity will now be rejected with a 400 Bad Request error.

🔥 Fixes

   - #4 
  
📸Evidence
<img width="989" height="854" alt="image" src="https://github.com/user-attachments/assets/0ef71533-c7bf-4baa-81b1-029a75730e9e" />
